### PR TITLE
Leave arrays as arrays (don't convert to objects). Fixes #14.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@google-cloud/firestore": "^0.13.0",
     "colors": "^1.2.0-rc0",
     "commander": "^2.14.1",
-    "core-js": "^2.5.3",
+    "core-js": "^2.5.5",
     "firebase-admin": "^5.9.1",
     "firebase-functions": "^0.8.1",
     "load-json-file": "^4.0.0",

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,9 +1,9 @@
-// From https://stackoverflow.com/questions/8495687/split-array-into-chunks
 import * as admin from "firebase-admin";
 import DocumentReference = admin.firestore.DocumentReference;
 import GeoPoint = admin.firestore.GeoPoint;
 import Firestore = FirebaseFirestore.Firestore;
 
+// From https://stackoverflow.com/questions/8495687/split-array-into-chunks
 const array_chunks = (array: Array<any>, chunk_size: number): Array<Array<any>> => {
   return Array(Math.ceil(array.length / chunk_size))
     .fill(null)
@@ -24,7 +24,11 @@ const serializeSpecialTypes = (data: any) => {
     } else if (value instanceof DocumentReference) {
       value = {__datatype__: 'documentReference', value: value.path};
     } else if (value === Object(value)) {
+      let isArray = Array.isArray(value);
       value = serializeSpecialTypes(value);
+      if (isArray) {
+        value = Object.keys(value).map(key => value[key]);
+      }
     }
     cleaned[key] = value;
   });
@@ -49,11 +53,16 @@ const unserializeSpecialTypes = (data: any, fs: Firestore) => {
             break;
         }
       } else {
+        let isArray = Array.isArray(value);
         value = unserializeSpecialTypes(value, fs);
+        if (isArray) {
+          value = Object.keys(value).map(key => value[key])
+        }
       }
     }
     cleaned[key] = value;
   });
   return cleaned;
 };
+
 export {array_chunks, serializeSpecialTypes, unserializeSpecialTypes};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "es6",
       "es2015",
       "es2017",
-      "dom"
+      "dom",
+      "es2017.object"
     ],
     "typeRoots": [
       "node_modules/@types",

--- a/yarn.lock
+++ b/yarn.lock
@@ -724,9 +724,13 @@ copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
-core-js@^2.0.0, core-js@^2.5.3:
+core-js@^2.0.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+
+core-js@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Fixes #14.

Changes proposed in this pull request:
- Imports and exports arrays as arrays (doesn't convert them to objects)

