### PR TITLE
Make merge option public

### DIFF
--- a/src/lib/import.ts
+++ b/src/lib/import.ts
@@ -6,7 +6,8 @@ import {ICollection} from "../interfaces/ICollection";
 const importData = (data: any,
                     startingRef: admin.firestore.Firestore |
                       FirebaseFirestore.DocumentReference |
-                      FirebaseFirestore.CollectionReference): Promise<any> => {
+                      FirebaseFirestore.CollectionReference,
+                      mergeWithExisting: boolean = true): Promise<any> => {
 
   const dataToImport = {...data};
   if (isLikeDocument(startingRef)) {
@@ -18,7 +19,7 @@ const importData = (data: any,
     const collectionPromises: Array<Promise<any>> = [];
     for (const collection in collections) {
       if (collections.hasOwnProperty(collection)) {
-        collectionPromises.push(setDocuments(collections[collection], startingRef.collection(collection)));
+        collectionPromises.push(setDocuments(collections[collection], startingRef.collection(collection), mergeWithExisting));
       }
     }
     if (isRootOfDatabase(startingRef)) {
@@ -27,16 +28,16 @@ const importData = (data: any,
       const documentID = startingRef.id;
       const documentData: any = {};
       documentData[documentID] = dataToImport;
-      const documentPromise = setDocuments(documentData, startingRef.parent);
+      const documentPromise = setDocuments(documentData, startingRef.parent, mergeWithExisting);
       return documentPromise.then(() => Promise.all(collectionPromises));
     }
   }
   else {
-    return setDocuments(dataToImport, <FirebaseFirestore.CollectionReference>startingRef);
+    return setDocuments(dataToImport, <FirebaseFirestore.CollectionReference>startingRef, mergeWithExisting);
   }
 };
 
-const setDocuments = (data: ICollection, startingRef: FirebaseFirestore.CollectionReference): Promise<any> => {
+const setDocuments = (data: ICollection, startingRef: FirebaseFirestore.CollectionReference, mergeWithExisting: boolean = true): Promise<any> => {
   console.log(`Writing documents for ${startingRef.path}`);
   if ('__collections__' in data) {
     throw new Error('Found unexpected "__collection__" in collection data. Does the starting node match' +
@@ -57,14 +58,14 @@ const setDocuments = (data: ICollection, startingRef: FirebaseFirestore.Collecti
         delete(data[documentKey]['__collections__']);
       }
       const documentData: any = unserializeSpecialTypes(data[documentKey], startingRef.firestore);
-      batch.set(startingRef.doc(documentKey), documentData, {merge: true});
+      batch.set(startingRef.doc(documentKey), documentData, {merge: mergeWithExisting});
     });
     return batch.commit();
   });
   return Promise.all(chunkPromises)
     .then(() => {
       return collections.map((col) => {
-        return setDocuments(col.collection, col.path);
+        return setDocuments(col.collection, col.path, mergeWithExisting);
       })
     })
     .then(subCollectionPromises => Promise.all(subCollectionPromises))


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Make merge option public

For my usecase it was important to update the complete dataset and not merge it with the existing one. For that I made the `merge` parameter configurable via the `mergeWithExisting` new parameter. It has also its default value set to `true`, so there should be no breaking change at all.

