### PR TITLE
Constrain memory consumption by using batched promise execution

### DIFF
--- a/src/lib/clear.ts
+++ b/src/lib/clear.ts
@@ -1,4 +1,4 @@
-import {isLikeDocument, isRootOfDatabase, sleep} from './firestore-helpers';
+import {batchExecutor, isLikeDocument, isRootOfDatabase, sleep} from './firestore-helpers';
 import * as admin from 'firebase-admin';
 import DocumentReference = FirebaseFirestore.DocumentReference;
 
@@ -39,7 +39,7 @@ const clearCollections = async (startingRef: admin.firestore.Firestore | Firebas
   collectionsSnapshot.map((collectionRef: FirebaseFirestore.CollectionReference) => {
     collectionPromises.push(clearDocuments(collectionRef));
   });
-  return Promise.all(collectionPromises);
+  return batchExecutor(collectionPromises);
 };
 
 const clearDocuments = async (collectionRef: FirebaseFirestore.CollectionReference) => {
@@ -64,7 +64,7 @@ const clearDocuments = async (collectionRef: FirebaseFirestore.CollectionReferen
     documentPromises.push(clearCollections(docRef));
     documentPromises.push(docRef.delete());
   });
-  return Promise.all(documentPromises);
+  return batchExecutor(documentPromises);
 };
 
 export default clearData;

--- a/src/lib/firestore-helpers.ts
+++ b/src/lib/firestore-helpers.ts
@@ -49,7 +49,7 @@ const sleep = (timeInMS: number): Promise<void> => new Promise(resolve => setTim
 const batchExecutor = async function<T>(promises: Promise<T>[], batchSize: number = 50) {
   const res: T[] = [];
   while (promises.length > batchSize) {
-    const temp = await Promise.all(promises.splice(0, 50));
+    const temp = await Promise.all(promises.splice(0, batchSize));
     res.push(...temp)
   }
   if (promises.length > 0) {

--- a/src/lib/firestore-helpers.ts
+++ b/src/lib/firestore-helpers.ts
@@ -46,6 +46,19 @@ const isRootOfDatabase = (ref: admin.firestore.Firestore |
 
 const sleep = (timeInMS: number): Promise<void> => new Promise(resolve => setTimeout(resolve, timeInMS));
 
+const batchExecutor = async function<T>(promises: Promise<T>[], batchSize: number = 50) {
+  const res: T[] = [];
+  while (promises.length > batchSize) {
+    const temp = await Promise.all(promises.splice(0, 50));
+    res.push(...temp)
+  }
+  if (promises.length > 0) {
+    const temp = await Promise.all(promises);
+    res.push(...temp)
+  }
+  return res;
+};
+
 export {
   getCredentialsFromFile,
   getFirestoreDBReference,
@@ -53,4 +66,5 @@ export {
   isLikeDocument,
   isRootOfDatabase,
   sleep,
+  batchExecutor
 };

--- a/tests/firestore-helpers.spec.ts
+++ b/tests/firestore-helpers.spec.ts
@@ -1,6 +1,7 @@
 import 'mocha';
 import {expect} from 'chai';
 import {
+  batchExecutor,
   getCredentialsFromFile,
   getDBReferenceFromPath,
   isLikeDocument,
@@ -71,7 +72,6 @@ describe('Firestore Helpers', () => {
         })
     });
 
-
     describe('getDBReferenceFromPath()', () => {
         it('should create a document reference with the requested path', () => {
             const mockFirestore = new firebasemock.MockFirestore();
@@ -88,4 +88,26 @@ describe('Firestore Helpers', () => {
         });
     });
 
+    describe('batchExecutor', () => {
+
+      const toPromise = async function(x: any) {return x;};
+
+      it('should resolve lists smaller then the batchsize', async () => {
+        const input = [toPromise(1), toPromise(2)];
+        let actual = await batchExecutor(input, 3);
+        expect(actual).to.eql([1,2]);
+      });
+
+      it('should resolve lists equal to the batchsize', async () => {
+        const input = [toPromise(1), toPromise(2)];
+        let actual = await batchExecutor(input, 1);
+        expect(actual).to.eql([1,2]);
+      });
+
+      it('should resolve lists larger then the batchsize', async () => {
+        const input = [toPromise(1), toPromise(2)];
+        let actual = await batchExecutor(input, 1);
+        expect(actual).to.eql([1,2]);
+      });
+    });
 });


### PR DESCRIPTION
Fixes #74 .

Instead of `await Promise.all`, use a batched approach. All promises could mean 20.000+ promises, which is to much for the max RAM that a Cloud Function can handle. Using this batched approach the memory consumption is constrained, but it is still as performant timewise as without batching. 
The order of the documents might change due to timing issues, but the overall content is identical.