### PR TITLE
Fixed batchExecutor to not be useless

### DIFF
--- a/src/lib/clear.ts
+++ b/src/lib/clear.ts
@@ -23,10 +23,10 @@ const clearData = async (startingRef: admin.firestore.Firestore |
 };
 
 const clearCollections = async (startingRef: admin.firestore.Firestore | FirebaseFirestore.DocumentReference, logs = false) => {
-  const collectionPromises: Array<Promise<any>> = [];
+  const collectionPromises: Array<() => Promise<any>> = [];
   const collectionsSnapshot = await safelyGetCollectionsSnapshot(startingRef, logs);
   collectionsSnapshot.map((collectionRef: FirebaseFirestore.CollectionReference) => {
-    collectionPromises.push(clearDocuments(collectionRef, logs));
+    collectionPromises.push(() => clearDocuments(collectionRef, logs));
   });
   return batchExecutor(collectionPromises);
 };
@@ -34,10 +34,10 @@ const clearCollections = async (startingRef: admin.firestore.Firestore | Firebas
 const clearDocuments = async (collectionRef: FirebaseFirestore.CollectionReference, logs = false) => {
   logs && console.log(`Retrieving documents from ${collectionRef.path}`);
   const allDocuments = await safelyGetDocumentReferences(collectionRef, logs);
-  const documentPromises: Array<Promise<object>> = [];
+  const documentPromises: Array<() => Promise<object>> = [];
   allDocuments.forEach((docRef: DocumentReference) => {
-    documentPromises.push(clearCollections(docRef, logs));
-    documentPromises.push(docRef.delete());
+    documentPromises.push(() => clearCollections(docRef, logs));
+    documentPromises.push(() => docRef.delete());
   });
   return batchExecutor(documentPromises);
 };

--- a/src/lib/firestore-helpers.ts
+++ b/src/lib/firestore-helpers.ts
@@ -45,11 +45,11 @@ const isRootOfDatabase = (ref: admin.firestore.Firestore |
 
 const sleep = (timeInMS: number): Promise<void> => new Promise(resolve => setTimeout(resolve, timeInMS));
 
-const batchExecutor = async function <T>(promises: Promise<T>[], batchSize: number = 50) {
+const batchExecutor = async function <T>(promiseGenerators: (() => Promise<T>)[], batchSize: number = 50) {
   const res: T[] = [];
-  while (promises.length > 0) {
-    const temp = await Promise.all(promises.splice(0, batchSize));
-    res.push(...temp);
+  while (promiseGenerators.length > 0) {
+    const promises = promiseGenerators.splice(0, batchSize).map(generator => generator());
+    res.push(...await Promise.all(promises));
   }
   return res;
 };

--- a/tests/firestore-helpers.spec.ts
+++ b/tests/firestore-helpers.spec.ts
@@ -98,19 +98,19 @@ describe('Firestore Helpers', () => {
     };
 
     it('should resolve lists smaller then the batchsize', async () => {
-      const input = [toPromise(1), toPromise(2)];
+      const input = [() => toPromise(1), () => toPromise(2)];
       let actual = await batchExecutor(input, 3);
       expect(actual).to.eql([1, 2]);
     });
 
     it('should resolve lists equal to the batchsize', async () => {
-      const input = [toPromise(1), toPromise(2)];
+      const input = [() => toPromise(1), () => toPromise(2)];
       let actual = await batchExecutor(input, 1);
       expect(actual).to.eql([1, 2]);
     });
 
     it('should resolve lists larger then the batchsize', async () => {
-      const input = [toPromise(1), toPromise(2)];
+      const input = [() => toPromise(1), () => toPromise(2)];
       let actual = await batchExecutor(input, 1);
       expect(actual).to.eql([1, 2]);
     });


### PR DESCRIPTION
`Promise.all()` doesn't trigger the promises to start their work, creating the promise itself does. Reference:
https://stackoverflow.com/a/40639551

Currently, all `batchExecutor` does is waiting for the promises in chunks, but they're still all executed in parallel. This pull request changes the code so that instead of (already running) promises, promise generator functions are passed, so that the promises are created (and actually executed) in chunks.

Another unfixed issue is that `batchExecutor` is used recursively, so if the batch limit is, say, 50, and the tree depth is 3, the limit is actually `50^3=125000` since each `batchExecutor` instance manages its own limit.