### PR TITLE
Ignore accountCredentials param if using emulator

### DIFF
--- a/src/lib/firestore-helpers.ts
+++ b/src/lib/firestore-helpers.ts
@@ -1,18 +1,23 @@
 import * as admin from 'firebase-admin';
 import loadJsonFile from 'load-json-file';
 import {IFirebaseCredentials} from '../interfaces/IFirebaseCredentials';
+import process from "process";
 
 const SLEEP_TIME = 1000;
 
-const getCredentialsFromFile = (credentialsFilename: string): Promise<IFirebaseCredentials> => {
-  return loadJsonFile(credentialsFilename);
+const getCredentialsFromFile = (credentialsFilename?: string): Promise<IFirebaseCredentials> | undefined => {
+  return credentialsFilename ?  loadJsonFile(credentialsFilename) : undefined;
 };
 
-const getFirestoreDBReference = (credentials: IFirebaseCredentials): admin.firestore.Firestore => {
-  admin.initializeApp({
+const getProjectIdFromCredentials = (credentials?: any): string => {
+  return process.env.FIRESTORE_EMULATOR_HOST || credentials.project_id;
+}
+
+const getFirestoreDBReference = (credentials?: IFirebaseCredentials): admin.firestore.Firestore => {
+  admin.initializeApp(credentials ? {
     credential: admin.credential.cert(credentials as any),
     databaseURL: `https://${(credentials as any).project_id}.firebaseio.com`,
-  });
+  } : {});
 
   return admin.firestore();
 };
@@ -98,6 +103,7 @@ type anyFirebaseRef = admin.firestore.Firestore |
 
 export {
   getCredentialsFromFile,
+  getProjectIdFromCredentials,
   getFirestoreDBReference,
   getDBReferenceFromPath,
   isLikeDocument,

--- a/tests/firestore-helpers.spec.ts
+++ b/tests/firestore-helpers.spec.ts
@@ -3,6 +3,7 @@ import {expect} from 'chai';
 import {
   batchExecutor,
   getCredentialsFromFile,
+  getProjectIdFromCredentials,
   getDBReferenceFromPath,
   isLikeDocument,
   isRootOfDatabase,
@@ -64,7 +65,14 @@ describe('Firestore Helpers', () => {
   });
 
   describe('getCredentialsFromFile()', () => {
-    it(`should fail if the file doesn't exist`, async () => {
+    const env = Object.assign({}, process.env);
+
+    it(`should return undefined if using emulator`, async () => {
+      process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080'
+      const credentials = await getCredentialsFromFile();
+      expect(credentials).be.undefined;
+    });
+    it(`should fail if not using emulator and the file doesn't exist`, async () => {
       const dummyFilename = 'i_do_not_exist.json';
       try {
         await getCredentialsFromFile(dummyFilename);
@@ -73,6 +81,29 @@ describe('Firestore Helpers', () => {
         expect(e).to.exist;
       }
     });
+
+    afterEach(() => {
+      process.env = env;
+    })
+  });
+
+  describe('getProjectIdFromCredentials()', () => {
+    const env = Object.assign({}, process.env);
+
+    it(`should get emulator host if using emulator`, async () => {
+      process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080'
+      const projectId = getProjectIdFromCredentials();
+      expect(projectId).to.equal('localhost:8080');
+    });
+
+    it(`should get projectId if not using emulator`, async () => {
+      const projectId = getProjectIdFromCredentials({ project_id: 'testProjectId' });
+      expect(projectId).to.equal('testProjectId');
+    });
+
+    afterEach(() => {
+      process.env = env;
+    })
   });
 
   describe('getDBReferenceFromPath()', () => {


### PR DESCRIPTION
Changes proposed in this pull request:
- Ignore param `accountCredentials` if using emulator (enviroment variable `FIRESTORE_EMULATOR_HOST` is set). The script was throwing an error if not setting `accountCredentials` (even if it was not using it).
- Centralised the logic that checks for param/file existence of param `accountCredentials`
- Centralised the logic that checks for param/file existence of param `backupFile `

