### PR TITLE
fix: random test bug.

### DIFF
--- a/tests/helpers.spec.ts
+++ b/tests/helpers.spec.ts
@@ -75,7 +75,7 @@ describe('Helpers', () => {
       expect(chunks).to.have.lengthOf(Math.floor(expectedLengthOfChunks));
 
       const lastItem = chunks.pop();
-      expect(lastItem).to.have.lengthOf(expectedRemainder);
+      expect(lastItem).to.have.lengthOf(expectedRemainder || startingArraySize);
     });
   });
 


### PR DESCRIPTION
Changes proposed in this pull request:


Test is failed when `expectedRemainder` is zero.

If the return value of `Math.random()` is divisible by 100, `expectedRemainder` is zero.



